### PR TITLE
hadolint for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sander1/xtables_geoip
+FROM sander1/xtables_geoip:latest
 
 # FROM alpine:3.8.4
 
@@ -7,7 +7,7 @@ WORKDIR /opt
 
 RUN \
   apk add --no-cache --update \
-    python2 
+    python2=2.7.15-r3
 
 COPY ./xt_rebuild.sh ./xt_geoip_*.py /opt/GeoLite2xtables/
 


### PR DESCRIPTION
Run it with

    docker run --rm -i hadolint/hadolint < ./Dockerfile

It still complains because of the latest tag for base image but there is no other image published.